### PR TITLE
Fix #11: Ensure inspector updates correctly on extension reload

### DIFF
--- a/bug_1542035.patch
+++ b/bug_1542035.patch
@@ -2,7 +2,7 @@
 # User Bianca Danforth <bdanforth@mozilla.com>
 # Date 1556821965 25200
 #      Thu May 02 11:32:45 2019 -0700
-# Node ID 10e5d3a0601d295cb436d94e338e5d6c4dc95740
+# Node ID fc97b9e0fc91b642e84e263db69084976bc019c2
 # Parent  a0403c2bfae40a8b3cebd532ce730fa824181fee
 Bug 1542035 - Prototype extension local storage in addon developer toolbox
 
@@ -701,11 +701,27 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
  StorageActors.createActor({
    typeName: "Cache",
  }, {
+@@ -2688,9 +3137,12 @@ const StorageActor = protocol.ActorClass
+         (!subject.location.href || subject.location.href == "about:blank")) {
+       return null;
+     }
+-
+-    if (topic == "content-document-global-created" &&
+-        this.isIncludedInTopLevelWindow(subject)) {
++    // We don't want to try to find a top level window for an extension page, as
++    // in many cases (e.g. background page), it is not loaded in a tab, and
++    // 'isIncludedInTopLevelWindow' throws an error
++    if (topic == "content-document-global-created"
++      && (subject.location.href.startsWith("moz-extension://")
++      || this.isIncludedInTopLevelWindow(subject))) {
+       this.childWindowPool.add(subject);
+       this.emit("window-ready", subject);
+     } else if (topic == "inner-window-destroyed") {
 diff --git a/devtools/server/tests/unit/test_extension_storage_actor.js b/devtools/server/tests/unit/test_extension_storage_actor.js
 new file mode 100644
 --- /dev/null
 +++ b/devtools/server/tests/unit/test_extension_storage_actor.js
-@@ -0,0 +1,554 @@
+@@ -0,0 +1,622 @@
 +/* Any copyright is dedicated to the Public Domain.
 +   http://creativecommons.org/publicdomain/zero/1.0/ */
 +
@@ -771,18 +787,21 @@ new file mode 100644
 +* background script if provided
 +* @param {Object} options.files - An object whose keys correspond to file names and
 +* values map to the file contents
++* @param {Object} options.manifest - An object representing the extension's manifest
 +* @return {Object} - The extension configuration object
 +*/
 +function getExtensionConfig(options = {}) {
++  const {manifest, ...otherOptions} = options;
 +  const baseConfig = {
 +    manifest: {
++      ...manifest,
 +      permissions: ["storage"],
 +    },
 +    useAddonManager: "temporary",
 +  };
 +  return {
 +    ...baseConfig,
-+    ...options,
++    ...otherOptions,
 +  };
 +}
 +
@@ -1257,6 +1276,71 @@ new file mode 100644
 +
 +  Services.prefs.setBoolPref(LEAVE_STORAGE_PREF, false);
 +  Services.prefs.setBoolPref(LEAVE_UUID_PREF, false);
++
++  await shutdown(extension, target);
++});
++
++/**
++* Test case: Bg page adds an item to storage. With inspector open, reload extension.
++* - Load extension with background page that adds a storage item on message.
++* - Open the add-on inspector.
++* - With the inspector still open, reload the extension.
++* - The data in the inspector should match the item added prior to reloading.
++*/
++add_task(async function test_local_storage_live_reload() {
++  const EXTENSION_ID = "test_local_storage_live_reload@xpcshell.mozilla.org";
++  let manifest = {
++    version: "1.0",
++    applications: {
++      gecko: {
++        id: EXTENSION_ID,
++      },
++    },
++  };
++
++  info("Loading extension version 1.0");
++  const extension = ExtensionTestUtils.loadExtension(
++    getExtensionConfig({
++      manifest,
++      background: extensionScriptWithMessageListener,
++    })
++  );
++
++  info("Starting up extension");
++  await extension.startup();
++
++  info("Waiting for message from test extension");
++  const host = await extension.awaitMessage("extension-origin");
++
++  info("Adding storage item");
++  extension.sendMessage("storage-local-set", {a: 123});
++  await extension.awaitMessage("storage-local-set:done");
++
++  const {target} = await setupExtensionDebugging(extension.id);
++  // This effectively opens the storage inspector by calling listStores
++  const extensionStorage = await getExtensionStorage(target);
++
++  manifest = {
++    ...manifest,
++    version: "2.0",
++  };
++  // "Reload" is most similar to an upgrade, as e.g. storage data is preserved
++  info("Update to version 2.0");
++  await extension.upgrade(
++    getExtensionConfig({
++      manifest,
++      background: extensionScriptWithMessageListener,
++    }),
++  );
++
++  await extension.awaitMessage("extension-origin");
++
++  const {data} = await extensionStorage.getStoreObjects(host);
++  Assert.deepEqual(
++    data,
++    [{name: "a", value: {str: "123"}}],
++    "Got the expected results on populated storage.local"
++  );
 +
 +  await shutdown(extension, target);
 +});

--- a/bug_1542035.patch
+++ b/bug_1542035.patch
@@ -2,7 +2,7 @@
 # User Bianca Danforth <bdanforth@mozilla.com>
 # Date 1556821965 25200
 #      Thu May 02 11:32:45 2019 -0700
-# Node ID 552998087ee64dec1342012f24813a2b409bb807
+# Node ID 0873cee608107ad541747c63f36c7d3b3f2f41e3
 # Parent  a0403c2bfae40a8b3cebd532ce730fa824181fee
 Bug 1542035 - Prototype extension local storage in addon developer toolbox
 
@@ -721,7 +721,7 @@ diff --git a/devtools/server/tests/unit/test_extension_storage_actor.js b/devtoo
 new file mode 100644
 --- /dev/null
 +++ b/devtools/server/tests/unit/test_extension_storage_actor.js
-@@ -0,0 +1,628 @@
+@@ -0,0 +1,696 @@
 +/* Any copyright is dedicated to the Public Domain.
 +   http://creativecommons.org/publicdomain/zero/1.0/ */
 +
@@ -1345,6 +1345,74 @@ new file mode 100644
 +  Assert.deepEqual(
 +    data,
 +    [{name: "a", value: {str: "123"}}],
++    "Got the expected results on populated storage.local"
++  );
++
++  await shutdown(extension, target);
++});
++
++/**
++* Test case: Bg page automatically adds item(s). With inspector open, reload extension.
++* - Load extension with background page that automatically adds a storage item on startup.
++* - Open the add-on inspector.
++* - With the inspector still open, reload the extension.
++* - The data in the inspector should match the item(s) added by the reloaded extension.
++*/
++add_task(async function test_local_storage_live_reload_bg_page_auto_adds_items() {
++  async function background() {
++    await browser.storage.local.set({a: {b: 123}, c: {d: 456}});
++    browser.test.sendMessage("extension-origin", window.location.origin);
++  }
++  const EXTENSION_ID = "test_local_storage_live_reload@xpcshell.mozilla.org";
++  let manifest = {
++    version: "1.0",
++    applications: {
++      gecko: {
++        id: EXTENSION_ID,
++      },
++    },
++  };
++
++  info("Loading extension version 1.0");
++  const extension = ExtensionTestUtils.loadExtension(
++    getExtensionConfig({
++      manifest,
++      background,
++    })
++  );
++
++  info("Starting up extension");
++  await extension.startup();
++
++  info("Waiting for message from test extension");
++  const host = await extension.awaitMessage("extension-origin");
++
++  const {target} = await setupExtensionDebugging(extension.id);
++  // This effectively opens the storage inspector by calling listStores
++  const extensionStorage = await getExtensionStorage(target);
++
++  manifest = {
++    ...manifest,
++    version: "2.0",
++  };
++  // "Reload" is most similar to an upgrade, as e.g. storage data is preserved
++  info("Update to version 2.0");
++  await extension.upgrade(
++    getExtensionConfig({
++      manifest,
++      background,
++    }),
++  );
++
++  await extension.awaitMessage("extension-origin");
++
++  const {data} = await extensionStorage.getStoreObjects(host);
++  Assert.deepEqual(
++    data,
++    [
++      {name: "a", value: {str: "{\"b\":123}"}},
++      {name: "c", value: {str: "{\"d\":456}"}},
++    ],
 +    "Got the expected results on populated storage.local"
 +  );
 +

--- a/bug_1542035.patch
+++ b/bug_1542035.patch
@@ -2,7 +2,7 @@
 # User Bianca Danforth <bdanforth@mozilla.com>
 # Date 1556821965 25200
 #      Thu May 02 11:32:45 2019 -0700
-# Node ID 0873cee608107ad541747c63f36c7d3b3f2f41e3
+# Node ID 472a492899253af94e27319be7a742b8f975b1c9
 # Parent  a0403c2bfae40a8b3cebd532ce730fa824181fee
 Bug 1542035 - Prototype extension local storage in addon developer toolbox
 
@@ -721,7 +721,7 @@ diff --git a/devtools/server/tests/unit/test_extension_storage_actor.js b/devtoo
 new file mode 100644
 --- /dev/null
 +++ b/devtools/server/tests/unit/test_extension_storage_actor.js
-@@ -0,0 +1,696 @@
+@@ -0,0 +1,764 @@
 +/* Any copyright is dedicated to the Public Domain.
 +   http://creativecommons.org/publicdomain/zero/1.0/ */
 +
@@ -1340,6 +1340,74 @@ new file mode 100644
 +  );
 +
 +  await extension.awaitMessage("extension-origin");
++
++  const {data} = await extensionStorage.getStoreObjects(host);
++  Assert.deepEqual(
++    data,
++    [{name: "a", value: {str: "123"}}],
++    "Got the expected results on populated storage.local"
++  );
++
++  await shutdown(extension, target);
++});
++
++/**
++* Test case: Transient page adds an item to storage. With inspector open,
++* reload extension.
++* - Load extension open transient page that adds a storage item on message.
++* - Open the add-on storage inspector.
++* - With the inspector still open, reload the extension.
++* - The data in the inspector should match the item added prior to reloading.
++*/
++add_task(async function test_local_storage_live_reload_no_bg_page() {
++  const EXTENSION_ID = "test_local_storage_live_reload@xpcshell.mozilla.org";
++  let manifest = {
++    version: "1.0",
++    applications: {
++      gecko: {
++        id: EXTENSION_ID,
++      },
++    },
++  };
++
++  info("Loading extension version 1.0");
++  const extension = ExtensionTestUtils.loadExtension(getExtensionConfig({
++    manifest,
++    files: ext_no_bg.files,
++  }));
++
++  info("Starting up extension");
++  await extension.startup();
++
++  info("Opening extension page in a tab");
++  const url = extension.extension.baseURI.resolve("extension_page_in_tab.html");
++  const contentPage = await ExtensionTestUtils.loadContentPage(url, {extension});
++
++  const host = await extension.awaitMessage("extension-origin");
++
++  info("Waiting for extension page in a tab to add storage item");
++  extension.sendMessage("storage-local-set", {a: 123});
++  await extension.awaitMessage("storage-local-set:done");
++
++  await contentPage.close();
++
++  info("Opening storage inspector");
++  const {target} = await setupExtensionDebugging(extension.id);
++  // This effectively opens the storage inspector by calling listStores
++  const extensionStorage = await getExtensionStorage(target);
++
++  manifest = {
++    ...manifest,
++    version: "2.0",
++  };
++  // "Reload" is most similar to an upgrade, as e.g. storage data is preserved
++  info("Updating extension to version 2.0");
++  await extension.upgrade(
++    getExtensionConfig({
++      manifest,
++      files: ext_no_bg.files,
++    })
++  );
 +
 +  const {data} = await extensionStorage.getStoreObjects(host);
 +  Assert.deepEqual(

--- a/bug_1542035.patch
+++ b/bug_1542035.patch
@@ -2,7 +2,7 @@
 # User Bianca Danforth <bdanforth@mozilla.com>
 # Date 1556821965 25200
 #      Thu May 02 11:32:45 2019 -0700
-# Node ID fc97b9e0fc91b642e84e263db69084976bc019c2
+# Node ID 552998087ee64dec1342012f24813a2b409bb807
 # Parent  a0403c2bfae40a8b3cebd532ce730fa824181fee
 Bug 1542035 - Prototype extension local storage in addon developer toolbox
 
@@ -721,7 +721,7 @@ diff --git a/devtools/server/tests/unit/test_extension_storage_actor.js b/devtoo
 new file mode 100644
 --- /dev/null
 +++ b/devtools/server/tests/unit/test_extension_storage_actor.js
-@@ -0,0 +1,622 @@
+@@ -0,0 +1,628 @@
 +/* Any copyright is dedicated to the Public Domain.
 +   http://creativecommons.org/publicdomain/zero/1.0/ */
 +
@@ -745,6 +745,9 @@ new file mode 100644
 +  createAppInfo,
 +  promiseStartupManager,
 +} = AddonTestUtils;
++
++const LEAVE_UUID_PREF = "extensions.webextensions.keepUuidOnUninstall";
++const LEAVE_STORAGE_PREF = "extensions.webextensions.keepStorageOnUninstall";
 +
 +AddonTestUtils.init(this);
 +createAppInfo("xpcshell@tests.mozilla.org", "XPCShell", "1", "42");
@@ -1220,11 +1223,9 @@ new file mode 100644
 +add_task(async function test_local_storage_ext_data_added_prior_to_ext_startup() {
 +  // The pref to leave the addonid->uuid mapping around after uninstall so that we can
 +  // re-attach to the same storage
-+  const LEAVE_UUID_PREF = "extensions.webextensions.keepUuidOnUninstall";
 +  Services.prefs.setBoolPref(LEAVE_UUID_PREF, true);
 +
 +  // The pref to prevent cleaning up storage on uninstall
-+  const LEAVE_STORAGE_PREF = "extensions.webextensions.keepStorageOnUninstall";
 +  Services.prefs.setBoolPref(LEAVE_STORAGE_PREF, true);
 +
 +  let extension = ExtensionTestUtils.loadExtension(
@@ -1278,6 +1279,11 @@ new file mode 100644
 +  Services.prefs.setBoolPref(LEAVE_UUID_PREF, false);
 +
 +  await shutdown(extension, target);
++});
++
++add_task(function cleanup_for_test_local_storage_ext_data_added_prior_to_ext_startup() {
++  Services.prefs.setBoolPref(LEAVE_UUID_PREF, false);
++  Services.prefs.setBoolPref(LEAVE_STORAGE_PREF, false);
 +});
 +
 +/**


### PR DESCRIPTION
1. Add `test_local_storage_live_reload` task (Background page adds an item to storage. With the storage inspector open, reload extension.)
  - Load extension with background page that adds a storage item on message.
  - Open the add-on inspector.
  - With the inspector still open, reload the extension.
  - The data in the inspector should match the item added prior to reloading.
2. Add `test_local_storage_live_reload_bg_page_auto_adds_items` task (background page automatically adds item(s). With the storage inspector open, reload extension)
  - Load extension with background page that automatically adds a storage item on startup.
  - Open the add-on inspector.
  - With the inspector still open, reload the extension.
  - The data in the inspector should match the item(s) added by the reloaded extension.
3. Add `test_local_storage_live_reload_no_bg_page` (transient page adds an item to storage. With inspector open, reload extension.)
- Load extension open transient page that adds a storage item on message.
- Open the add-on storage inspector.
- With the inspector still open, reload the extension.
- The data in the inspector should match the item added prior to reloading.

**Questions re: case 1**
1. In my test, I want to reload the extension while the storage inspector is _opened_. When I try to call 'extensionStorage.getStoreObjects' after the reload (using the 'extensionStorage' object obtained before the reload), I am getting an error (at bottom).
  * Am I using the right proxy for opening the inspector when I call 'getExtensionStorage'?
  * Is the "reload" button a true uninstall/reinstall?
  * Am I going about this test in the right way?
  * Where/when is my 'extensionStorage' store getting destroyed?

```
Error: Can not send request because front 'extensionStorage' is already destroyed.
Stack trace:
generateRequestMethods/</frontProto[name]@resource://devtools/shared/protocol.js:1493:15
test_local_storage_live_reload@chrome://mochitests/content/browser/devtools/server/tests/browser/browser_storage_webext_storage_local.js:485:41
Async*Tester_execTest/<@chrome://mochikit/content/browser-test.js:1116:34
Tester_execTest@chrome://mochikit/content/browser-test.js:1144:12
nextTest/<@chrome://mochikit/content/browser-test.js:1005:14
SimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<@chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:803:59
```

2. I’m trying to add the first test case for this issue ('test_local_storage_live_reload'), and I think I may want to do something similar to 'test_local_storage_ext_data_added_prior_to_ext_startup' that uses test prefs: Do I want to set 'extensions.webextensions.keepUuidOnUninstall' to 'true'?
  * If so, should I move both of these tasks to their own mochitest file? (otherwise I am duplicating the special powers code for both tasks).

3. When I manually test case 1 (with [this extension](https://send.firefox.com/download/d09f642488b242ae/#FT4cklX4gQMtyy9bq80HMQ), I get the following errors in the console upon clicking "Reload" in `about:debugging`: I should check whether any of these errors outside of my storage actor are causing the buggy behavior I am seeing in the panel.
![Screen Shot 2019-05-01 at 8 55 14 PM](https://user-images.githubusercontent.com/17437436/57055938-b833d200-6c53-11e9-818f-736a69339c0b.png)
