### PR TITLE
Fix #28: Deserialize StructuredCloneHolder values in onStorageChange

### DIFF
--- a/bug_1542035.patch
+++ b/bug_1542035.patch
@@ -2,7 +2,7 @@
 # User Bianca Danforth <bdanforth@mozilla.com>
 # Date 1556821965 25200
 #      Thu May 02 11:32:45 2019 -0700
-# Node ID 373c0464c9181dbdaa709c383e88cb94b5a794af
+# Node ID 0d09cc87b098a3b828c2b1e9afc5d1f3bb95e03f
 # Parent  df3eadfa74a8061f4c88496404d51baf47e21070
 Bug 1542035 - Prototype extension local storage in addon developer toolbox
 
@@ -250,7 +250,7 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
  loader.lazyRequireGetter(this, "naturalSortCaseInsensitive",
    "devtools/client/shared/natural-sort", true);
  
-@@ -1298,6 +1303,442 @@ StorageActors.createActor({
+@@ -1298,6 +1303,450 @@ StorageActors.createActor({
    observationTopics: ["dom-storage2-changed", "dom-private-storage2-changed"],
  }, getObjectForLocalOrSessionStorage("sessionStorage"));
  
@@ -469,7 +469,15 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
 +
 +    for (const key in changes) {
 +      const storageChange = changes[key];
-+      const {newValue, oldValue} = storageChange;
++      let {newValue, oldValue} = storageChange;
++      if (newValue && typeof newValue === "object"
++        && Cu.getClassName(newValue, true) === "StructuredCloneHolder") {
++        newValue = newValue.deserialize(this);
++      }
++      if (oldValue && typeof oldValue === "object"
++        && Cu.getClassName(oldValue, true) === "StructuredCloneHolder") {
++        oldValue = oldValue.deserialize(this);
++      }
 +
 +      let action;
 +      if (typeof newValue === "undefined") {
@@ -708,7 +716,7 @@ diff --git a/devtools/server/tests/unit/test_extension_storage_actor.js b/devtoo
 new file mode 100644
 --- /dev/null
 +++ b/devtools/server/tests/unit/test_extension_storage_actor.js
-@@ -0,0 +1,543 @@
+@@ -0,0 +1,554 @@
 +/* Any copyright is dedicated to the Public Domain.
 +   http://creativecommons.org/publicdomain/zero/1.0/ */
 +
@@ -943,13 +951,24 @@ new file mode 100644
 +  let {data} = await extensionStorage.getStoreObjects(host);
 +  Assert.deepEqual(data, [], "Got the expected results on empty storage.local");
 +
-+  extension.sendMessage("storage-local-set", {a: 123});
++  extension.sendMessage("storage-local-set", {
++    a: 123,
++    b: [4, 5],
++    c: {d: 678},
++    d: true,
++    e: "hi",
++  });
 +  await extension.awaitMessage("storage-local-set:done");
 +
 +  data = (await extensionStorage.getStoreObjects(host)).data;
 +  Assert.deepEqual(
-+    data,
-+    [{name: "a", value: {str: "123"}}],
++    data, [
++      {name: "a", value: {str: "123"}},
++      {name: "b", value: {str: "[4,5]"}},
++      {name: "c", value: {str: "{\"d\":678}"}},
++      {name: "d", value: {str: "true"}},
++      {name: "e", value: {str: "hi"}},
++    ],
 +    "Got the expected results on populated storage.local"
 +  );
 +

--- a/bug_1542035.patch
+++ b/bug_1542035.patch
@@ -2,8 +2,8 @@
 # User Bianca Danforth <bdanforth@mozilla.com>
 # Date 1556821965 25200
 #      Thu May 02 11:32:45 2019 -0700
-# Node ID 0d09cc87b098a3b828c2b1e9afc5d1f3bb95e03f
-# Parent  df3eadfa74a8061f4c88496404d51baf47e21070
+# Node ID 10e5d3a0601d295cb436d94e338e5d6c4dc95740
+# Parent  a0403c2bfae40a8b3cebd532ce730fa824181fee
 Bug 1542035 - Prototype extension local storage in addon developer toolbox
 
 diff --git a/devtools/client/shared/vendor/moz.build b/devtools/client/shared/vendor/moz.build
@@ -701,17 +701,6 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
  StorageActors.createActor({
    typeName: "Cache",
  }, {
-diff --git a/devtools/server/tests/browser/browser.ini b/devtools/server/tests/browser/browser.ini
---- a/devtools/server/tests/browser/browser.ini
-+++ b/devtools/server/tests/browser/browser.ini
-@@ -127,6 +127,7 @@ skip-if = e10s # Bug 1183605 - devtools/
- [browser_storage_listings.js]
- [browser_storage_updates.js]
- skip-if = (verify && debug && (os == 'mac' || os == 'linux'))
-+[browser_storage_webext_storage_local.js]
- [browser_stylesheets_getTextEmpty.js]
- [browser_stylesheets_nested-iframes.js]
- [browser_register_actor.js]
 diff --git a/devtools/server/tests/unit/test_extension_storage_actor.js b/devtools/server/tests/unit/test_extension_storage_actor.js
 new file mode 100644
 --- /dev/null


### PR DESCRIPTION
I figured out where the array or object literal value for a storage item is getting wrongly changed. It's actually not in my storage actor, but at [this line](https://searchfox.org/mozilla-central/source/toolkit/components/extensions/child/ext-storage.js#81) in toolkit/components/extensions/child/ext-storage.js.

I have logged this fact in this WIP patch:
```diff
diff --git a/toolkit/components/extensions/child/ext-storage.js b/toolkit/components/extensions/child/ext-storage.js
--- a/toolkit/components/extensions/child/ext-storage.js
+++ b/toolkit/components/extensions/child/ext-storage.js
@@ -83,6 +83,7 @@ this.storage = class extends ExtensionAP
           });

           if (changes) {
+            console.log("getLocalIDBBackend.set", "items: ", items, "changes:", changes);
             fireOnChanged(changes);
           }
         });
```

And what I get is:
```
 0:02.37 pid:51623 console.log: WebExtensions: getLocalIDBBackend.set items:  {"b":[4,5]} changes: {"b":{"newValue":{}}}
```

I have not dug into why `db.set` is doing this... I am going to ask rpl, as this may be a bit out of my depth...

Note: If this PR merges before #26  (which it will, likely), don't forget to add [this commit](https://github.com/biancadanforth/bug_1542035/pull/24/commits/5e898c601c63c99e2c7915aacd0403f51d650961) to this PR, since rebasing a .patch file doesn't work.