### PR TITLE
WIP Fix #13: Don't list 'extensionStorage' storage actor in non-addon toolboxes

### DIFF
--- a/bug_1542035.patch
+++ b/bug_1542035.patch
@@ -2,7 +2,7 @@
 # User Bianca Danforth <bdanforth@mozilla.com>
 # Date 1556821965 25200
 #      Thu May 02 11:32:45 2019 -0700
-# Node ID f34e54e6578a3ef7ead2505e1c633659c0033386
+# Node ID d07c3b1ebf44d7aa412f438d8012f9a349eea274
 # Parent  9b2f851979cb8d0dd0cd2618656eddee32e4f143
 Bug 1542035 - Prototype extension local storage in addon developer toolbox
 
@@ -755,6 +755,66 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
        this.childWindowPool.add(subject);
        this.emit("window-ready", subject);
      } else if (topic == "inner-window-destroyed") {
+@@ -2745,6 +3200,11 @@ const StorageActor = protocol.ActorClass
+     const toReturn = {};
+ 
+     for (const [name, value] of this.childActorPool) {
++      // Only list extensionStorage for the add-on storage panel
++      if (name === "extensionStorage"
++        && (!value.storageActor.parentActor.addonId)) {
++        continue;
++      }
+       if (value.preListStores) {
+         await value.preListStores();
+       }
+diff --git a/devtools/server/tests/browser/browser.ini b/devtools/server/tests/browser/browser.ini
+--- a/devtools/server/tests/browser/browser.ini
++++ b/devtools/server/tests/browser/browser.ini
+@@ -127,6 +127,7 @@ skip-if = e10s # Bug 1183605 - devtools/
+ [browser_storage_listings.js]
+ [browser_storage_updates.js]
+ skip-if = (verify && debug && (os == 'mac' || os == 'linux'))
++[browser_storage_webext_storage_local.js]
+ [browser_stylesheets_getTextEmpty.js]
+ [browser_stylesheets_nested-iframes.js]
+ [browser_register_actor.js]
+diff --git a/devtools/server/tests/browser/browser_storage_webext_storage_local.js b/devtools/server/tests/browser/browser_storage_webext_storage_local.js
+new file mode 100644
+--- /dev/null
++++ b/devtools/server/tests/browser/browser_storage_webext_storage_local.js
+@@ -0,0 +1,32 @@
++/* vim: set ft=javascript ts=2 et sw=2 tw=80: */
++/* Any copyright is dedicated to the Public Domain.
++http://creativecommons.org/publicdomain/zero/1.0/ */
++
++"use strict";
++
++add_task(async function test_extension_store_disabled_for_non_extension_target_process() {
++  // Pref remains in effect until test completes and is automatically cleared afterwards
++  await SpecialPowers.pushPrefEnv({
++    set: [["devtools.storage.extensionStorage.enabled", true]],
++  });
++
++  info("Setting up and connecting Debugger Server and Client in main process");
++  initDebuggerServer();
++  const transport = DebuggerServer.connectPipe();
++  const client = new DebuggerClient(transport);
++  await client.connect();
++
++  info("Opening a non-extension page in a tab");
++  const target = await addTabTarget("data:text/html;charset=utf-8,");
++
++  info("Getting all stores for the target process");
++  const storageFront = await target.getFront("storage");
++  const stores = await storageFront.listStores();
++
++  ok(
++    !("extensionStorage" in stores),
++    "Should not have an extensionStorage store when non-extension process is targeted"
++  );
++
++  target.destroy();
++});
 diff --git a/devtools/server/tests/unit/test_extension_storage_actor.js b/devtools/server/tests/unit/test_extension_storage_actor.js
 new file mode 100644
 --- /dev/null


### PR DESCRIPTION
Add 'test_extension_store_disabled_for_non_addon_toolboxes' task.

This is currently failing, as the 'processId' I am getting back from the 'contentPage' is 0. The error:
```
 0:01.03 ERROR Unexpected exception Protocol error (forbidden): You are not allowed to debug chrome.
```